### PR TITLE
Fix to Master

### DIFF
--- a/lib/game_stats.rb
+++ b/lib/game_stats.rb
@@ -1,8 +1,8 @@
-require './lib/stats'
+require_relative 'stats'
 
 class GameStats < Stats
   def initialize(games)
-    super(games)
+    super(games, teams, game_teams)
   end
 
   def highest_total_score

--- a/lib/league_stats.rb
+++ b/lib/league_stats.rb
@@ -19,6 +19,16 @@ class LeagueStats < Stats
     find_name(worst_offense_id)
   end
 
+  def best_defense
+    best_defense_id = defense_helper.max_by { |id, goals| goals }.first
+    find_name(best_defense_id)
+  end
+
+  def worst_defense
+    worst_defense_id = defense_helper.min_by { |id, goals| goals }.first
+    find_name(worst_defense_id)
+  end
+
   def lowest_scoring_visitor
     scoring('away','low')
   end
@@ -69,16 +79,6 @@ class LeagueStats < Stats
       end
     end
     team_names
-  end
-
-  def best_defense
-    best_defense_id = defense_helper.max_by { |id, goals| goals }.first
-    find_name(best_defense_id)
-  end
-
-  def worst_defense
-    worst_defense_id = defense_helper.min_by { |id, goals| goals }.first
-    find_name(worst_defense_id)
   end
 
 # Helper Methods

--- a/lib/league_stats.rb
+++ b/lib/league_stats.rb
@@ -1,4 +1,4 @@
-require './lib/stats'
+require_relative 'stats'
 
 class LeagueStats < Stats
   def initialize(games, teams, game_teams)

--- a/lib/modules/data_loadable.rb
+++ b/lib/modules/data_loadable.rb
@@ -1,7 +1,6 @@
 require 'csv'
 
 module DataLoadable
-
   def csv_data(file_path, object)
     csv = CSV.open(file_path, headers: :first_row, header_converters: :symbol)
     csv.map{ |row| object.new(row) }

--- a/lib/season_stats.rb
+++ b/lib/season_stats.rb
@@ -1,4 +1,4 @@
-require './lib/stats'
+require_relative 'stats'
 
 class SeasonStats < Stats
   def initialize(games, teams, game_teams)

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -73,6 +73,14 @@ class StatTracker
     @league_stats.worst_offense
   end
 
+  def best_defense
+    @league_stats.best_defense
+  end
+
+  def worst_defense
+    @league_stats.worst_defense
+  end
+
   def highest_scoring_visitor
     @league_stats.highest_scoring_visitor
   end

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -3,8 +3,8 @@ require_relative 'team'
 require_relative 'game_team'
 require_relative 'game_stats'
 require_relative 'league_stats'
-# require_relative 'season_stats'
-# require_relative 'team_stats'
+require_relative 'season_stats'
+require_relative 'team_stats'
 require_relative './modules/data_loadable'
 
 class StatTracker
@@ -21,8 +21,8 @@ class StatTracker
     @game_teams = csv_data(locations[:game_teams], GameTeam)
     @game_stats = GameStats.new(@games)
     @league_stats = LeagueStats.new(@games, @teams, @game_teams)
-    # @season_stats = SeasonStats.new(@games, @game_teams, @teams)
-    # @team_stats = TeamStats.new(@games, @game_teams, @teams)
+    @season_stats = SeasonStats.new(@games, @game_teams, @teams)
+    @team_stats = TeamStats.new(@games, @game_teams, @teams)
   end
 
   def highest_total_score

--- a/lib/team_stats.rb
+++ b/lib/team_stats.rb
@@ -1,4 +1,4 @@
-require './lib/stats'
+require_relative 'stats'
 
 class TeamStats < Stats
   def initialize(games, teams, game_teams)

--- a/test/league_stats_test.rb
+++ b/test/league_stats_test.rb
@@ -42,13 +42,13 @@ class LeagueStatsTest < Minitest::Test
     assert_equal "FC Cincinnati", @league_stats.worst_offense
   end
 
-  # def test_best_defense
-  #
-  # end
+  def test_best_defense
+    assert_equal "Orlando City SC", @league_stats.best_defense
+  end
 
-  # def test_worst_defense
-  #
-  # end
+  def test_worst_defense
+    assert_equal "Sky Blue FC", @league_stats.worst_defense
+  end
 
   def test_highest_scoring_visitor
     assert_equal "Real Salt Lake", @league_stats.highest_scoring_visitor

--- a/test/stat_tracker_test.rb
+++ b/test/stat_tracker_test.rb
@@ -80,6 +80,14 @@ class StatTrackerTest < Minitest::Test
     assert_equal "FC Cincinnati", @stat_tracker.worst_offense
   end
 
+  def test_it_can_best_defense
+    assert_equal "Orlando City SC", @stat_tracker.best_defense
+  end
+
+  def test_it_can_worst_defense
+    assert_equal "Sky Blue FC", @stat_tracker.worst_defense
+  end
+
   def test_it_can_highest_scoring_visitor
     assert_equal "Real Salt Lake", @stat_tracker.highest_scoring_visitor
   end


### PR DESCRIPTION
With the introduction of the superstats merge, I overlooked two problems which slightly broke the program:

1. The program no longer worked
    * This was due to GameStats calling super(games) instead of super(games, teams, game_teams). I thought that since none of the GameStats used teams or game_teams, it didn't need to be passed in (wrong!). This PR sets the super call in line 5 of GameStats to now read `super(games, teams, game_teams)`

2. Rspec no longer worked
    * This was due to Rspec needing a require_relative instead of require when setting the file location of the Stats superclass in GameStats, LeagueStats, SeasonStats, and TeamStats. This PR changes the first line of these class files to now read `require_relative 'stats'`. 

Other fixes:
* Adds methods for best/worst defense to StatTracker (mirroring methods in LeagueStats)
* Add tests for these two methods to stat_tracker_test and league_stats_test

Metrics:
* Spec harness passes in 0.5275 seconds.
* Rake passes all files. 
* SimpleCov report 97.58% coverage.
    * The remaining 2.42% is because our SeasonStats, LeagueStats, and two associated test files don't do anything (no methods written for those iterations yet).


